### PR TITLE
Fix FontManager method call compilation error

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -222,7 +222,7 @@ void OTTOAudioProcessorEditor::initializeManagers()
     
     // Debug: Check if fonts loaded
     if (fontManager->hasError()) {
-        DBG("FontManager Error: " + fontManager->getError());
+        DBG("FontManager Error: " + fontManager->getLastError());
     }
     
     if (!fontManager->arePhosphorFontsLoaded()) {


### PR DESCRIPTION
# Fix FontManager method call compilation error

## Summary
This PR fixes a compilation error in `PluginEditor.cpp` where code was calling the non-existent `FontManager::getError()` method instead of the correct `FontManager::getLastError()` method. This was preventing OTTO from compiling on Apple Silicon Macs and blocking CLion configuration.

The error occurred during font loading debug logging and would cause the compiler to fail with: `error: no member named 'getError' in 'FontManager'; did you mean 'getLastError'?`

## Review & Testing Checklist for Human
- [ ] **Test compilation on Apple Silicon Mac** - Verify the project builds without FontManager method call errors
- [ ] **Test error logging functionality** - Trigger a font loading error (e.g., corrupted font files) and verify debug messages still appear correctly  
- [ ] **Verify method equivalence** - Confirm `getLastError()` returns the same error information as originally intended

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    PluginEditor["Source/PluginEditor.cpp<br/>Line 225 method call"]:::minor-edit
    FontManager["Source/FontManager.h<br/>API definition"]:::context
    CLion["CLion Compilation<br/>Apple Silicon"]:::context
    
    FontManager -->|"getLastError() method"| PluginEditor
    PluginEditor -->|"Enables compilation"| CLion
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes
- This is a simple method name correction but critical for Apple Silicon compilation
- The changed code is in a debug-only path that executes when font loading encounters errors
- Part of the larger effort to enable CLion configuration for macOS and iOS simulator targets
- Changes were developed on Linux targeting macOS, so thorough testing on actual Apple hardware is essential

**Link to Devin run**: https://app.devin.ai/sessions/055afd58229a4b4095f041189ed92664  
**Requested by**: Larry Seyer (@larryseyer)