### PR TITLE
Fix drumkit menu positioning and font consistency

### DIFF
--- a/Source/INIConfig.h
+++ b/Source/INIConfig.h
@@ -1542,7 +1542,7 @@ namespace LayoutConstants {
        constexpr int selectedLabelWidth = static_cast<int>(Defaults::DEFAULT_INTERFACE_WIDTH * (selectedLabelWidthPercent / 100.0f));
        constexpr int selectedLabelHeight = static_cast<int>(contentHeight * (selectedLabelHeightPercent / 100.0f));
        constexpr int selectedLabelX = dropdownX + ((dropdownWidth - selectedLabelWidth) / 2); // Center under dropdown
-       constexpr int selectedLabelY = contentY + contentHeight - selectedLabelHeight - (buttonSpacing / 2); // Bottom of Row 3 with small gap
+       constexpr int selectedLabelY = contentY + ((contentHeight - selectedLabelHeight) / 2); // Center in Row 3
 
        // Total width calculation for validation
        constexpr int totalUsedWidth = mixerButtonX + mixerButtonSize + defaultMargin - startX;

--- a/Source/MainContentComponent.cpp
+++ b/Source/MainContentComponent.cpp
@@ -629,7 +629,8 @@ void MainContentComponent::setupRow3Components() {
     drumKitSelectedLabel.setComponentID("drumkit_selected_label");
     drumKitSelectedLabel.setText("808 Classic", juce::dontSendNotification); // Default to match dropdown
     drumKitSelectedLabel.setJustificationType(juce::Justification::centred);
-    // Font will be set automatically by CustomLookAndFeel::getLabelFont via component ID
+    // Use same font as preset menu via FontManager
+    drumKitSelectedLabel.setFont(fontManager.getFont(FontManager::FontRole::Header, INIConfig::LayoutConstants::fontSizePresetMenuReduced));
     drumKitSelectedLabel.setColour(juce::Label::textColourId, colorScheme.getColor(ColorScheme::ColorRole::PrimaryText));
     drumKitSelectedLabel.setColour(juce::Label::backgroundColourId, colorScheme.getColor(ColorScheme::ColorRole::ComponentBackground));
     
@@ -789,8 +790,7 @@ void MainContentComponent::comboBoxChanged(juce::ComboBox* comboBoxThatHasChange
         DBG("DrumKit selected: " << selectedText << " (ID: " << selectedId << ")");
         
         // Hide menu after selection (following preset pattern)
-        showingDrumKitLabel = true;
-        updateDrumKitDisplayToggle();
+        showDrumKitLabel();
         
         // Notify parent component of drumkit change
         if (onDrumKitChanged) {


### PR DESCRIPTION
# Fix drumkit menu positioning and font consistency

## Summary

Fixed two UI issues with the drumkit menu in Row 3:

1. **Positioning Issue**: The drumkit label was appearing on Row 5 instead of Row 3 due to incorrect positioning calculation in INI constants
2. **Font Consistency**: Updated drumkit label to use the same font system as the preset menu for visual consistency

**Key Changes:**
- Modified `Row3::selectedLabelY` calculation in `INIConfig.h` to center the label in Row 3 instead of positioning it at the bottom
- Updated drumkit label font application in `MainContentComponent.cpp` to explicitly use `FontManager::FontRole::Header` with `fontSizePresetMenuReduced` (matching preset menu pattern)
- Leveraged existing toggle mechanism and CustomLookAndFeel support that was already implemented

The fix follows the established preset menu pattern exactly, ensuring consistent behavior and styling across both menu types.

## Review & Testing Checklist for Human

- [ ] **Visual verification**: Load the application and confirm drumkit label now appears centered in Row 3 (not Row 5)
- [ ] **Font consistency**: Compare drumkit label font with preset menu font - should look identical in size and typeface  
- [ ] **Interactive behavior**: Test clicking drumkit label shows dropdown, selecting item hides dropdown and shows label
- [ ] **Layout integrity**: Verify no overlap or spacing issues with other Row 3 components (chevrons, buttons, etc.)
- [ ] **No regressions**: Confirm preset menu still works correctly and other rows are unaffected

**Recommended Test Plan:**
1. Build and run the full JUCE application  
2. Navigate to the interface and locate Row 3 (drumkit section)
3. Verify label positioning and font appearance
4. Test the label/dropdown toggle functionality
5. Compare with preset menu behavior for consistency

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    INIConfig["INIConfig.h<br/>Row3::selectedLabelY"]:::major-edit
    MainContent["MainContentComponent.cpp<br/>drumKitSelectedLabel setup"]:::minor-edit  
    CustomLook["CustomLookAndFeel.cpp<br/>getLabelFont method"]:::context
    
    INIConfig --> |"provides positioning<br/>constants"| MainContent
    CustomLook --> |"already handles<br/>drumkit_selected_label"| MainContent
    
    MainContent --> |"positions label<br/>in Row 3"| Row3["Row 3 Layout<br/>(drumkit section)"]:::context
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#ADD8E6  
    classDef context fill:#FFFFFF
```

### Notes

**Implementation Details:**
- Changed positioning from `contentY + contentHeight - selectedLabelHeight - (buttonSpacing / 2)` (bottom of Row 3) to `contentY + ((contentHeight - selectedLabelHeight) / 2)` (center of Row 3)
- The toggle mechanism methods (`updateDrumKitDisplayToggle`, `showDrumKitLabel`, `showDrumKitMenu`) were already implemented, so no changes needed there
- CustomLookAndFeel already had proper support for `drumkit_selected_label` component ID

**Testing Limitation:** 
⚠️ I was only able to run a command-line demo of OTTO, not the full JUCE GUI application, so these changes require human verification of the visual appearance and behavior.

**Session Info:**
- Requested by: Larry Seyer (@larryseyer)  
- Link to Devin run: https://app.devin.ai/sessions/b7d388a4537949468204bfada9a28a39