### PR TITLE
Fix coordinate system transformation for all rows 3-6

### DIFF
--- a/Source/INIConfig.h
+++ b/Source/INIConfig.h
@@ -1519,7 +1519,7 @@ namespace LayoutConstants {
 
        // DrumKit dropdown positioning (centered between chevrons)
        constexpr int dropdownX = leftChevronX + leftChevronSize + buttonSpacing;
-       constexpr int dropdownY = contentY + ((contentHeight - dropdownHeight) / 2);
+       constexpr int dropdownY = defaultPadding + ((contentHeight - dropdownHeight) / 2);
 
        // Right chevron button positioning
        constexpr int rightChevronX = dropdownX + dropdownWidth + buttonSpacing;
@@ -1538,7 +1538,7 @@ namespace LayoutConstants {
 
        // DrumKit selected label positioning - centered below dropdown
        constexpr float selectedLabelWidthPercent = 15.0f;        // 15% of interface width
-       constexpr float selectedLabelHeightPercent = 25.0f;       // 25% of content height
+       constexpr float selectedLabelHeightPercent = 80.0f;       // 80% of content height (full Row 3 space)
        constexpr int selectedLabelWidth = static_cast<int>(Defaults::DEFAULT_INTERFACE_WIDTH * (selectedLabelWidthPercent / 100.0f));
        constexpr int selectedLabelHeight = static_cast<int>(contentHeight * (selectedLabelHeightPercent / 100.0f));
        constexpr int selectedLabelX = dropdownX + ((dropdownWidth - selectedLabelWidth) / 2); // Center under dropdown
@@ -1610,19 +1610,19 @@ namespace LayoutConstants {
 
        // Group label positioning
        constexpr int groupLabelX = startX;
-       constexpr int groupLabelY = contentY + ((contentHeight - labelHeight) / 2);
+       constexpr int groupLabelY = defaultPadding + ((contentHeight - labelHeight) / 2);
 
        // Pattern group dropdown positioning
        constexpr int dropdownX = groupLabelX + groupLabelWidth + componentSpacing;
-       constexpr int dropdownY = contentY + ((contentHeight - dropdownHeight) / 2);
+       constexpr int dropdownY = defaultPadding + ((contentHeight - dropdownHeight) / 2);
 
        // Status display positioning
        constexpr int statusX = dropdownX + dropdownWidth + componentSpacing;
-       constexpr int statusY = contentY + ((contentHeight - labelHeight) / 2);
+       constexpr int statusY = defaultPadding + ((contentHeight - labelHeight) / 2);
 
        // Action buttons positioning (add, delete, etc.)
        constexpr int firstActionButtonX = statusX + statusWidth + componentSpacing;
-       constexpr int actionButtonY = contentY + ((contentHeight - buttonHeight) / 2);
+       constexpr int actionButtonY = defaultPadding + ((contentHeight - buttonHeight) / 2);
        constexpr int secondActionButtonX = firstActionButtonX + actionButtonWidth + componentSpacing;
 
        // Total width calculation for validation

--- a/Source/MainContentComponent.cpp
+++ b/Source/MainContentComponent.cpp
@@ -970,7 +970,7 @@ void MainContentComponent::updateRow5Layout() {
     }
     
     // Row5 main positioning - 45% of interface height (largest content area)
-    int row5Y = layoutManager.scaled(Row5::yPosition);
+    int row5Y = layoutManager.scaled(defaultPadding + ROW_3_HEIGHT + ROW_4_HEIGHT);
     int row5Height = layoutManager.scaled(Row5::height);
     
     // Left Section: 4x4 Pattern Matrix (63.5% width) - optimized for matrix display
@@ -1026,7 +1026,7 @@ void MainContentComponent::updateRow6Layout() {
     auto bounds = getLocalBounds();
     
     // Row6 positioning - 12% of interface height (compact loop controls)
-    int row6Y = layoutManager.scaled(Row6::yPosition);
+    int row6Y = layoutManager.scaled(defaultPadding + ROW_3_HEIGHT + ROW_4_HEIGHT + ROW_5_HEIGHT);
     int row6Height = layoutManager.scaled(Row6::height);
     
     // Position LoopSectionComponent across full interface width


### PR DESCRIPTION
# Fix coordinate system transformation for all rows 3-6

## Summary

Fixes a systematic coordinate system transformation issue affecting rows 3-6 in the responsive, percentage-based layout system. The root cause was that all affected rows used absolute positioning (`contentY + offset`) while MainContentComponent applies a coordinate transformation via `mainContentOffset`, causing components to appear in wrong rows (e.g., drumkit label appearing in Row 5 instead of Row 3).

**Key Changes:**
- **Increased drumkit label height** from 35% to 80% of Row 3 content height for better visibility
- **Fixed Row 3 & 4 positioning constants** in INIConfig.h to use relative positioning (`defaultPadding + offset`) instead of absolute
- **Fixed Row 5 & 6 layout methods** in MainContentComponent.cpp to use calculated relative positions instead of absolute `yPosition` constants
- **Applied consistent coordinate transformation pattern** across all affected rows while maintaining existing row height percentages

## Review & Testing Checklist for Human

- [ ] **Visual verification on Mac GUI application** - Confirm drumkit label now appears on Row 3 instead of Row 5
- [ ] **Test drumkit label height increase** - Verify 80% height looks good and doesn't overlap other Row 3 components  
- [ ] **Verify all Row 3-6 components are positioned correctly** - Check that pattern groups, controls, and loop sections appear in their designated rows
- [ ] **Test responsive behavior** - Resize window and verify layout maintains correct proportions across different screen sizes
- [ ] **Cross-platform testing** - Test on different display scaling factors if possible

**Recommended Test Plan:**
1. Build and run the full JUCE GUI application on Mac
2. Verify drumkit controls (edit button, dropdown, label, mute/mixer buttons) are all in Row 3
3. Check that pattern group controls are properly positioned in Row 4  
4. Confirm Row 5 pattern matrix and Row 6 loop controls are in correct positions
5. Test window resizing to ensure responsive layout still works correctly

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    INIConfig["INIConfig.h<br/>Layout Constants"]:::major-edit
    MainContent["MainContentComponent.cpp<br/>Layout Methods"]:::major-edit
    Row3["Row 3: DrumKit Controls<br/>(12% height)"]:::context
    Row4["Row 4: Pattern Groups<br/>(12% height)"]:::context  
    Row5["Row 5: Main Controls<br/>(50% height)"]:::context
    Row6["Row 6: Loop Controls<br/>(8% height)"]:::context
    
    INIConfig -->|"Y position constants<br/>Fixed: contentY → defaultPadding"| Row3
    INIConfig -->|"Y position constants<br/>Fixed: contentY → defaultPadding"| Row4
    MainContent -->|"Layout calculation<br/>Fixed: yPosition → relative calc"| Row5
    MainContent -->|"Layout calculation<br/>Fixed: yPosition → relative calc"| Row6
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

**Testing Limitation:** I was only able to test the command-line demo application, not the full JUCE GUI, so visual verification of the positioning fixes is critical during human review.

**Coordinate System Background:** The OTTO application uses a 6-row percentage-based layout system where MainContentComponent handles rows 3-6 with a complex coordinate transformation. The issue was that positioning constants used absolute coordinates while the component applies relative transformations.

**Link to Devin run:** https://app.devin.ai/sessions/b7d388a4537949468204bfada9a28a39  
**Requested by:** Larry Seyer (@larryseyer)