### PR TITLE
Fix drumkit label positioning and toggle functionality

### DIFF
--- a/Source/MainContentComponent.cpp
+++ b/Source/MainContentComponent.cpp
@@ -876,11 +876,11 @@ void MainContentComponent::updateRow3Layout() {
                                 layoutManager.scaled(Row3::mixerButtonSize),
                                 layoutManager.scaled(Row3::mixerButtonSize));
     
-    // DrumKit selected label - positioned using INI constants with Playfair Display font
-    drumKitSelectedLabel.setBounds(startX + chevronSize + spacing + ((dropdownWidth - layoutManager.scaled(Row3::selectedLabelWidth)) / 2),
-                                  layoutManager.scaled(Row3::selectedLabelY),
-                                  layoutManager.scaled(Row3::selectedLabelWidth),
-                                  layoutManager.scaled(Row3::selectedLabelHeight));
+    // DrumKit selected label - positioned using IDENTICAL bounds as dropdown (following preset pattern)
+    drumKitSelectedLabel.setBounds(startX + chevronSize + spacing,
+                                  layoutManager.scaled(defaultPadding + ((Row3::contentHeight - Row3::dropdownHeight) / 2)),
+                                  dropdownWidth,
+                                  dropdownHeight);
     
     // ========================================================================
     // VALIDATION: Ensure all components fit within Row 3 bounds  


### PR DESCRIPTION
# Fix drumkit label positioning and toggle functionality

## Summary

This PR fixes the drumkit label positioning issue in Row 3 where the label was getting cut off. The fix follows the exact preset menu pattern from `TopBarComponent.cpp` (lines 1495-1496) by making `drumKitSelectedLabel` use identical bounds as `drumKitDropdown`.

**Key changes:**
- Modified `drumKitSelectedLabel.setBounds()` to use the same positioning logic as `drumKitDropdown`
- Removed usage of INI constants (`Row3::selectedLabelWidth`, `selectedLabelHeight`, `selectedLabelY`) that were causing the label to be positioned differently
- Now both components use identical bounds: `(startX + chevronSize + spacing, yPos, dropdownWidth, dropdownHeight)`

This ensures the label has the full dropdown width available and won't be cut off, while maintaining the existing toggle functionality and Playfair Display font support.

## Review & Testing Checklist for Human

- [ ] **Visual verification**: Build and run the application to confirm the drumkit label is no longer cut off in Row 3
- [ ] **Toggle functionality**: Test clicking the drumkit label switches to dropdown menu and vice versa
- [ ] **Font rendering**: Verify dropdown menu items display with Playfair Display font correctly
- [ ] **Layout regression testing**: Ensure no other Row 3 components are misaligned or affected by the positioning change

**Recommended test plan:**
1. Build and run the OTTO application
2. Navigate to Row 3 drumkit section
3. Verify the drumkit label text is fully visible (not cut off)
4. Click the drumkit label to test toggle to dropdown menu
5. Select different drumkits to verify the label updates correctly
6. Check that font styling matches the preset menu appearance

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    MainContentComponent["Source/MainContentComponent.cpp<br/>updateRow3Layout()"]:::major-edit
    TopBarComponent["Source/TopBarComponent.cpp<br/>preset pattern reference<br/>(lines 1495-1496)"]:::context
    CustomLookAndFeel["Source/CustomLookAndFeel.cpp<br/>getComboBoxFont()"]:::context
    
    MainContentComponent -->|"follows pattern from"| TopBarComponent
    MainContentComponent -->|"uses font from"| CustomLookAndFeel
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

**Environment limitation**: Unable to build and visually test the changes due to missing JuceLibraryCode in the development environment. The fix is based on code analysis and following the established preset pattern, but visual verification by the reviewer is critical.

**Link to Devin run**: https://app.devin.ai/sessions/3eaf79a1a34b494ebf4fec5fd9f4a76d  
**Requested by**: Larry Seyer (@larryseyer)

The change is straightforward but positioning fixes can be subtle, so manual testing of the UI is essential to confirm the fix works as expected.