### PR TITLE
Fix Row 4 layout overlap blocking drumkit label clicks

### DIFF
--- a/Source/MainContentComponent.cpp
+++ b/Source/MainContentComponent.cpp
@@ -903,7 +903,7 @@ void MainContentComponent::updateRow4Layout() {
     
     // Group Label positioning - left aligned with standard margin and FontManager
     patternGroupLabel.setBounds(layoutManager.scaled(Row4::groupLabelX),
-                               layoutManager.scaled(Row4::groupLabelY),
+                               layoutManager.scaled(Row4::yPosition + Row4::groupLabelY),
                                layoutManager.scaled(Row4::groupLabelWidth),
                                layoutManager.scaled(Row4::labelHeight));
     
@@ -913,13 +913,13 @@ void MainContentComponent::updateRow4Layout() {
     
     // Pattern Group Dropdown positioning - percentage-based responsive width
     patternGroupDropdown.setBounds(layoutManager.scaled(Row4::dropdownX),
-                                  layoutManager.scaled(Row4::dropdownY),
+                                  layoutManager.scaled(Row4::yPosition + Row4::dropdownY),
                                   layoutManager.scaled(Row4::dropdownWidth),
                                   layoutManager.scaled(Row4::dropdownHeight));
     
     // Status display positioning - shows pattern count information with FontManager
     patternStatusLabel.setBounds(layoutManager.scaled(Row4::statusX),
-                                layoutManager.scaled(Row4::statusY),
+                                layoutManager.scaled(Row4::yPosition + Row4::statusY),
                                 layoutManager.scaled(Row4::statusWidth),
                                 layoutManager.scaled(Row4::labelHeight));
     
@@ -929,13 +929,13 @@ void MainContentComponent::updateRow4Layout() {
     
     // Add button positioning - first action button with percentage-based sizing
     patternAddButton.setBounds(layoutManager.scaled(Row4::firstActionButtonX),
-                              layoutManager.scaled(Row4::actionButtonY),
+                              layoutManager.scaled(Row4::yPosition + Row4::actionButtonY),
                               layoutManager.scaled(Row4::actionButtonWidth),
                               layoutManager.scaled(Row4::buttonHeight));
     
     // Delete button positioning - second action button with percentage-based sizing
     patternDeleteButton.setBounds(layoutManager.scaled(Row4::secondActionButtonX),
-                                 layoutManager.scaled(Row4::actionButtonY),
+                                 layoutManager.scaled(Row4::yPosition + Row4::actionButtonY),
                                  layoutManager.scaled(Row4::actionButtonWidth),
                                  layoutManager.scaled(Row4::buttonHeight));
     


### PR DESCRIPTION
# Fix Row 4 layout overlap blocking drumkit label clicks

## Summary

Resolves layout overlap issue where Row 4 components (pattern group controls) were incorrectly positioned in Row 3 space, blocking clicks to the drumkit label and preventing the dropdown toggle functionality from working.

**Root cause**: Row 4 component Y coordinates were calculated as relative offsets within the content area, but missing the base `Row4::yPosition` offset needed for correct absolute screen positioning.

**Fix**: Added `Row4::yPosition +` to all Y coordinate calculations in `updateRow4Layout()` method for 5 components: `patternGroupLabel`, `patternGroupDropdown`, `patternStatusLabel`, `patternAddButton`, and `patternDeleteButton`.

This follows the same absolute positioning pattern used in other rows: `absolute_position = yPosition + relative_offset`.

## Review & Testing Checklist for Human

- [ ] **Visual verification**: Launch the app and verify Row 4 components (Group label, pattern dropdown, status labels, action buttons) appear in Row 4 space instead of overlapping Row 3
- [ ] **Drumkit label functionality**: Test clicking the drumkit label in Row 3 to confirm the dropdown menu now appears correctly
- [ ] **Row layout integrity**: Verify all 6 rows are positioned correctly per the layout specification and no new overlaps were introduced
- [ ] **Coordinate calculations**: Review the Y positioning math to ensure `Row4::yPosition + Row4::*Y` produces correct absolute coordinates

**Recommended test plan**: Build and run the app locally, visually inspect the row layout, and test drumkit label click functionality that was previously broken.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    INI["INIConfig.h<br/>Row4 Constants"]:::context
    MainComp["MainContentComponent.cpp<br/>updateRow4Layout()"]:::major-edit
    Row3["Row 3: DrumKit Controls<br/>(drumkit label, dropdown)"]:::context
    Row4["Row 4: Pattern Group Controls<br/>(group label, dropdown, buttons)"]:::context
    
    INI --> MainComp
    MainComp --> Row4
    Row3 -.-> Row4
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

**Important limitation**: The fix couldn't be visually tested since `run_local.sh` doesn't launch the full JUCE GUI. Visual verification by human reviewer is critical.

**Link to Devin run**: https://app.devin.ai/sessions/3eaf79a1a34b494ebf4fec5fd9f4a76d  
**Requested by**: Larry Seyer (@larryseyer)

The drumkit label click functionality was already properly implemented with mouseDown handler, toggle methods, and component setup - the issue was purely the layout overlap preventing clicks from reaching the label component.