### PR TITLE
Fix drumkit dropdown popup functionality and font styling

### DIFF
--- a/Source/MainContentComponent.cpp
+++ b/Source/MainContentComponent.cpp
@@ -625,6 +625,11 @@ void MainContentComponent::setupRow3Components() {
     
     addAndMakeVisible(drumKitDropdown);
     
+    // Set onPopupRequest callback to enable HierarchicalComboBox popup functionality
+    drumKitDropdown.onPopupRequest = [this]() {
+        juce::ComboBox::showPopup();
+    };
+    
     // DrumKit selected label - shows current selection with Playfair Display (following preset pattern)
     drumKitSelectedLabel.setComponentID("drumkit_selected_label");
     drumKitSelectedLabel.setText("808 Classic", juce::dontSendNotification); // Default to match dropdown


### PR DESCRIPTION
# Fix drumkit dropdown popup functionality and font styling

## Summary

Fixes the drumkit label click toggle functionality by adding the missing `onPopupRequest` callback to enable `HierarchicalComboBox` popup visibility. This addresses two reported issues:
1. Dropdown list not showing when clicking the drumkit label
2. Dropdown menu items not displaying with Playfair Display font

**Root cause**: `HierarchicalComboBox` overrides the standard `showPopup()` method to use a callback-based approach via `onPopupRequest`. Without this callback set, clicking the label calls `drumKitDropdown.showPopup()` but nothing happens because the callback is null.

**Solution**: Added the missing callback in `MainContentComponent.cpp` that calls `juce::ComboBox::showPopup()` to enable the standard popup mechanism.

## Review & Testing Checklist for Human

**🟡 Medium Risk - 3 items to verify:**

- [ ] **Critical: Test dropdown visibility** - Click the drumkit label in Row 3 and verify the dropdown menu actually appears (this functionality was completely broken before)
- [ ] **Critical: Verify font styling** - Confirm that dropdown menu items display with Playfair Display font as specified in the requirements  
- [ ] **Important: Test toggle behavior** - Verify the label/dropdown toggle works correctly (clicking label shows menu, clicking away or selecting an item hides it)

**Recommended test plan**: Build and run the full JUCE GUI application, navigate to Row 3, click the drumkit label, and verify both popup functionality and font styling work as expected.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
flowchart TD
    MainContent["Source/MainContentComponent.cpp<br/>setupRow3Components()"]:::major-edit
    HierarchicalCombo["Source/UtilityComponents.h/cpp<br/>HierarchicalComboBox"]:::context
    CustomLook["Source/CustomLookAndFeel.cpp<br/>getComboBoxFont()"]:::context
    TopBar["Source/TopBarComponent.cpp<br/>presetsMenu pattern"]:::context
    
    MainContent -->|"Added onPopupRequest callback"| HierarchicalCombo
    HierarchicalCombo -->|"showPopup() uses callback"| MainContent
    CustomLook -->|"Font styling for drumkit_dropdown"| MainContent
    TopBar -->|"Reference pattern"| MainContent
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- **Testing limitation**: The local `run_local.sh` script only runs a demo simulation, not the full JUCE GUI, so the dropdown functionality couldn't be visually verified during development
- **Font styling assumption**: The Playfair Display font handling code already exists in `CustomLookAndFeel.cpp` and should work automatically once the popup mechanism functions
- **Pattern consistency**: Follows the same callback approach used in `TopBarComponent.cpp` for the presets menu, but uses simpler `ComboBox::showPopup()` since drumkit items are already populated via `addItem()`

**Link to Devin run**: https://app.devin.ai/sessions/3eaf79a1a34b494ebf4fec5fd9f4a76d  
**Requested by**: Larry Seyer (@larryseyer)