### PR TITLE
Fix drumkit dropdown onPopupRequest callback compilation error

### DIFF
--- a/Source/MainContentComponent.cpp
+++ b/Source/MainContentComponent.cpp
@@ -627,7 +627,7 @@ void MainContentComponent::setupRow3Components() {
     
     // Set onPopupRequest callback to enable HierarchicalComboBox popup functionality
     drumKitDropdown.onPopupRequest = [this]() {
-        juce::ComboBox::showPopup();
+        drumKitDropdown.juce::ComboBox::showPopup();
     };
     
     // DrumKit selected label - shows current selection with Playfair Display (following preset pattern)


### PR DESCRIPTION
# Fix drumkit dropdown onPopupRequest callback compilation error

## Summary

This PR fixes a compilation error in the drumkit dropdown functionality where the `onPopupRequest` callback was incorrectly calling `this->showPopup()` on MainContentComponent (which doesn't have that method) instead of calling the ComboBox showPopup method on the drumKitDropdown instance.

**Key Change:**
- Changed `this->showPopup()` to `drumKitDropdown.juce::ComboBox::showPopup()` in the onPopupRequest callback (MainContentComponent.cpp:630)

This addresses the macOS build failure reported in PR #14 while maintaining the functionality to enable dropdown popup when clicking the drumkit label.

## Review & Testing Checklist for Human

- [ ] **Verify compilation succeeds on macOS** (original failure platform)
- [ ] **Test drumkit label click functionality** - clicking the label should show the dropdown menu
- [ ] **Verify Playfair Display font** - dropdown menu items should display with the correct Header font
- [ ] **Test toggle behavior** - verify switching between label and dropdown states works correctly

**Recommended Test Plan:**
1. Build the application on macOS (where original failure occurred)
2. Run the app and navigate to Row 3 (DrumKit Controls)
3. Click on the drumkit label and verify dropdown menu appears
4. Check that dropdown items use Playfair Display font
5. Test the toggle functionality between label/dropdown views

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    MainContent["Source/MainContentComponent.cpp<br/>setupRow3Components()"]:::major-edit
    HierarchicalCombo["HierarchicalComboBox<br/>onPopupRequest callback"]:::context
    CustomLookAndFeel["Source/CustomLookAndFeel.cpp<br/>getComboBoxFont()"]:::context
    
    MainContent -->|"calls showPopup() on"| HierarchicalCombo
    CustomLookAndFeel -->|"provides Playfair Display font"| HierarchicalCombo
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Limited Testing:** Due to environment constraints, I could only verify compilation/build on Linux, not the full UI functionality
- **Cross-Platform Concern:** Original failure was macOS-specific, so testing on that platform is critical
- **Part of Larger Feature:** This fix enables the drumkit dropdown popup, but complete functionality depends on existing font styling code in CustomLookAndFeel.cpp

**Link to Devin run:** https://app.devin.ai/sessions/3eaf79a1a34b494ebf4fec5fd9f4a76d  
**Requested by:** Larry Seyer (@larryseyer)